### PR TITLE
Fixed minor typo

### DIFF
--- a/slide-checklist.md
+++ b/slide-checklist.md
@@ -11,7 +11,7 @@ heroimage: https://developer-advocacy.com/images/slide-checklist.jpg
 This is a checklist for presenters to ensure that their talk materials
 are ready for an inclusive, accessible and actionable presentation. It
 is based on years of experience presenting in lots of different
-countries, to diverse audiences at at conferences with translation and
+countries, to diverse audiences at conferences with translation and
 transcription. It is also available online and you can [fork and
 contribute to it on GitHub](https://github.com/codepo8/talk-checklist/).
 


### PR DESCRIPTION
Fixed minor mistake at [Slide Checklist Page](https://github.com/codepo8/developer-advocacy-handbook/blob/main/slide-checklist.md)

<img width="1048" alt="Two 'at' at the Slide Checklist Page" src="https://github.com/user-attachments/assets/9c7616df-155b-4508-8aff-128be255a594" />
